### PR TITLE
feat/implement-sync-presence

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -26,34 +26,36 @@ model User {
 // 2. アクティビティログ (Transaction Table)
 // --------------------------------------
 model ActivityLog {
-  id           Int      @id @default(autoincrement())
+  id              Int      @id @default(autoincrement())
   
   // 紐付け設定
-  userId       String
-  user         User     @relation(fields: [userId], references: [userId])
+  userId          String
+  user            User     @relation(fields: [userId], references: [userId])
 
   // username は削除しました (Userテーブルのものを見るから不要)
   
   activityName String
-  startTime    DateTime @default(now())
-  endTime      DateTime?
-  createdAt    DateTime @default(now())
+  startTime       DateTime @default(now())
+  endTime         DateTime?
+  isUnexpectedEnd Boolean @default(false)
+  createdAt       DateTime @default(now())
 }
 
 // --------------------------------------
 // 3. ステータスログ (Transaction Table)
 // --------------------------------------
 model UserStatusLog {
-  id        Int      @id @default(autoincrement())
+  id              Int      @id @default(autoincrement())
   
   // 紐付け設定
-  userId    String
-  user      User     @relation(fields: [userId], references: [userId])
+  userId          String
+  user            User     @relation(fields: [userId], references: [userId])
   
-  status    String
-  startTime DateTime @default(now())
-  endTime   DateTime?
-  createdAt DateTime @default(now())
+  status          String
+  startTime       DateTime @default(now())
+  endTime         DateTime?
+  isUnexpectedEnd Boolean @default(false)
+  createdAt       DateTime @default(now())
 
   @@index([userId])
 }

--- a/bot/prisma/migrations/20251211050303_add_unexpected_end_flag/migration.sql
+++ b/bot/prisma/migrations/20251211050303_add_unexpected_end_flag/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ActivityLog" ADD COLUMN     "isUnexpectedEnd" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "UserStatusLog" ADD COLUMN     "isUnexpectedEnd" BOOLEAN NOT NULL DEFAULT false;

--- a/bot/prisma/schema.prisma
+++ b/bot/prisma/schema.prisma
@@ -26,34 +26,36 @@ model User {
 // 2. アクティビティログ (Transaction Table)
 // --------------------------------------
 model ActivityLog {
-  id           Int      @id @default(autoincrement())
+  id              Int      @id @default(autoincrement())
   
   // 紐付け設定
-  userId       String
-  user         User     @relation(fields: [userId], references: [userId])
+  userId          String
+  user            User     @relation(fields: [userId], references: [userId])
 
   // username は削除しました (Userテーブルのものを見るから不要)
   
   activityName String
-  startTime    DateTime @default(now())
-  endTime      DateTime?
-  createdAt    DateTime @default(now())
+  startTime       DateTime @default(now())
+  endTime         DateTime?
+  isUnexpectedEnd Boolean @default(false)
+  createdAt       DateTime @default(now())
 }
 
 // --------------------------------------
 // 3. ステータスログ (Transaction Table)
 // --------------------------------------
 model UserStatusLog {
-  id        Int      @id @default(autoincrement())
+  id              Int      @id @default(autoincrement())
   
   // 紐付け設定
-  userId    String
-  user      User     @relation(fields: [userId], references: [userId])
+  userId          String
+  user            User     @relation(fields: [userId], references: [userId])
   
-  status    String
-  startTime DateTime @default(now())
-  endTime   DateTime?
-  createdAt DateTime @default(now())
+  status          String
+  startTime       DateTime @default(now())
+  endTime         DateTime?
+  isUnexpectedEnd Boolean @default(false)
+  createdAt       DateTime @default(now())
 
   @@index([userId])
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -11,6 +11,7 @@ type ActivityLog = {
   status: string;
   startTime: string;
   endTime: string | null;
+  isUnexpectedEnd: boolean;
   createdAt: string;
 };
 
@@ -70,7 +71,7 @@ export default async function Home() {
                     {new Date(log.startTime).toLocaleString('ja-JP')}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {log.endTime ? '✅ Finished' : '🏃 Playing...'}
+                    {log.endTime ? (log.isUnexpectedEnd ? '⚠️ Unknown' : '✅ Finished') : '🏃 Playing...'}
                   </td>
                 </tr>
               ))}

--- a/web/src/app/status/page.tsx
+++ b/web/src/app/status/page.tsx
@@ -10,6 +10,7 @@ type UserStatusLog = {
   status: string;
   startTime: string;
   endTime: string | null;
+  isUnexpectedEnd: boolean;
   createdAt: string;
 };
 
@@ -87,7 +88,7 @@ export default async function Home() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                     {log.endTime ? (
-                      <span className="text-gray-400">Changed</span>
+                      log.isUnexpectedEnd ? '⚠️ Unknown' : <span className="text-gray-400">Changed</span>
                     ) : (
                       <span className="text-green-600 font-bold flex items-center gap-1">
                         <span className="relative flex h-2 w-2">


### PR DESCRIPTION
## 関連Issue
Fixes #17 
## やったこと
- 終了時刻を取得できなかったアクティビティ、ステータスを区別するカラムを追加
- bot起動時にアクティビティ、ステータスの終了、継続判定を追加
- 終了時刻が取得できなかった場合の状態を表示するようにページの一部を変更

## 確認方法
- bot停止中にdiscordのアクティビティなどを変更した後にbotを起動すると終了判定がunknownと表示される

## 備考
なし