### PR TITLE
feat: implement-discord-link-button

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "next": "16.0.7",
         "react": "19.2.0",
         "react-dom": "19.2.0",
+        "react-hot-toast": "^2.6.0",
         "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
@@ -2638,7 +2639,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3805,6 +3805,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -5450,6 +5459,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "next": "16.0.7",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "react-hot-toast": "^2.6.0",
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from '@/components/Header';
+import { Toaster } from 'react-hot-toast';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,6 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Header />
+        <Toaster position="bottom-right" reverseOrder={false} />
         {children}
       </body>
     </html>

--- a/web/src/app/users/[userId]/activities/page.tsx
+++ b/web/src/app/users/[userId]/activities/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import SearchBar from '@/components/SearchBar';
 import Pagination from '@/components/Pagination';
 import SocketListener from '@/components/SocketListener';
+import CopyButton from '@/components/CopyButton';
+import DiscordLinkButton from '@/components/DiscordLinkButton';
 
 // 1. 型定義 (以前と同じ)
 type ActivityLog = {
@@ -79,6 +81,16 @@ export default async function UserPage({
           <h1 className="text-3xl font-bold text-gray-800">
             {username}'s Activity
           </h1>
+          <div className="flex items-center gap-3 mt-2">
+            <span className="text-gray-500 font-mono text-sm bg-gray-100 px-2 py-1 rounded">
+              ID: {userId}
+            </span>
+            {/* コピーボタン */}
+            <CopyButton text={userId} />
+            
+            {/* ★ Discordリンクボタン */}
+            <DiscordLinkButton userId={userId} />
+          </div>
         </div>
 
         {/* 検索バー */}

--- a/web/src/app/users/[userId]/page.tsx
+++ b/web/src/app/users/[userId]/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import CopyButton from '@/components/CopyButton';
+import DiscordLinkButton from '@/components/DiscordLinkButton';
 
 // ユーザー情報を少しだけ取ってきたいので、最低限のfetchを用意
 async function getUser(userId: string) {
@@ -37,6 +39,16 @@ export default async function UserDashboard({ params }: { params: Promise<{ user
             <h1 className="text-3xl font-bold text-gray-800">
               {username}
             </h1>
+            <div className="flex items-center gap-3 mt-2">
+              <span className="text-gray-500 font-mono text-sm bg-gray-100 px-2 py-1 rounded">
+                ID: {userId}
+              </span>
+              {/* コピーボタン */}
+              <CopyButton text={userId} />
+              
+              {/* ★ Discordリンクボタン */}
+              <DiscordLinkButton userId={userId} />
+            </div>
             <p className="text-gray-500">User Dashboard</p>
           </div>
         </div>

--- a/web/src/app/users/[userId]/status/page.tsx
+++ b/web/src/app/users/[userId]/status/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import SearchBar from '@/components/SearchBar';
 import Pagination from '@/components/Pagination';
 import SocketListener from '@/components/SocketListener';
+import CopyButton from '@/components/CopyButton';
+import DiscordLinkButton from '@/components/DiscordLinkButton';
 
 // 1. 型定義
 type UserStatusLog = {
@@ -92,6 +94,16 @@ export default async function UserStatusPage({
           <h1 className="text-3xl font-bold text-gray-800">
             {username}'s Status History
           </h1>
+          <div className="flex items-center gap-3 mt-2">
+            <span className="text-gray-500 font-mono text-sm bg-gray-100 px-2 py-1 rounded">
+              ID: {userId}
+            </span>
+            {/* コピーボタン */}
+            <CopyButton text={userId} />
+            
+            {/* ★ Discordリンクボタン */}
+            <DiscordLinkButton userId={userId} />
+          </div>
         </div>
 
         {/* 検索バー */}

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+import toast from 'react-hot-toast'; // ★ import
+
+export default function CopyButton({ text, label = 'Copy ID' }: { text: string, label?: string }) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      
+      // ★ トーストを表示
+      toast.success('ID copied to clipboard!', {
+        style: {
+          border: '1px solid #4ade80',
+          padding: '16px',
+          color: '#166534',
+        },
+        iconTheme: {
+          primary: '#4ade80',
+          secondary: '#FFFAEE',
+        },
+      });
+
+      // アイコンを一時的にチェックマークに変える演出
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+
+    } catch (err) {
+      toast.error('Failed to copy');
+    }
+  };
+
+  return (
+    <button 
+      onClick={handleCopy} 
+      className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors px-3 py-1 rounded-md hover:bg-gray-100 border border-transparent hover:border-gray-200"
+      title="Click to copy"
+    >
+      {/* アイコンの切り替え */}
+      <span>{isCopied ? '✅' : '📋'}</span>
+      <span>{isCopied ? 'Copied!' : label}</span>
+    </button>
+  );
+}

--- a/web/src/components/DiscordLinkButton.tsx
+++ b/web/src/components/DiscordLinkButton.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export default function DiscordLinkButton({ userId }: { userId: string }) {
+  return (
+    <Link
+      href={`https://discord.com/users/${userId}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 bg-[#5865F2] hover:bg-[#4752C4] text-white px-4 py-2 rounded-md transition-colors text-sm font-medium shadow-sm"
+      title="Open Discord Profile"
+    >
+      {/* Discord Logo SVG */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        fill="currentColor"
+        viewBox="0 0 127.14 96.36"
+      >
+        <path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.11,77.11,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22c.63-15.02-2.08-41.58-18.9-72.15ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z" />
+      </svg>
+      <span>Discord Profile</span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## 関連Issue
Fixes: #27 
## やったこと
- discordプロフィールへの遷移ボタンを実装
- idのコピーbuttonを実装

## 確認方法
- ブラウザ上でリンクボタン、コピーボタンが機能することを確認

## 備考
